### PR TITLE
Import cleaned-up version of X-Sendfile patch.

### DIFF
--- a/install/config.php-template
+++ b/install/config.php-template
@@ -192,4 +192,16 @@ $gallery->setConfig('galleryBaseUrl', '');
  *           $gallery->setConfig('baseUri', 'https://example.com:8080/gallery2/index.php');
  */
 $gallery->setConfig('baseUri', '');
+
+
+/*
+ * Use X-Sendfile (or a similar header) to let the web server serve images directly
+ * to the client. This can significantly increase the performance of your Gallery.
+ * Supported web servers are lighttpd (since 1.4.24), nginx (using X-Accel-Redirect)
+ * and Apache (with mod_xsendfile).
+ * You need to configure your web server first to allow this header, since it can be a 
+ * security risk. See the appropriate documentation for details.
+ */
+$gallery->setConfig('useSendFile', false);
+
 ?>

--- a/modules/core/DownloadItem.inc
+++ b/modules/core/DownloadItem.inc
@@ -164,6 +164,18 @@ class DownloadItemView extends GalleryView {
 	    if ($stats[7] > 0) {
 		$phpVm->header('Content-length: ' . $stats[7]);
 	    }
+
+	    if ($gallery->getConfig('useSendFile')) {
+	    	if (strpos($_SERVER['SERVER_SOFTWARE'], 'lighttpd') === 0) {
+		    $phpVm->header('X-Sendfile: ' . $data['derivativePath']);
+		} else if (strpos($_SERVER['SERVER_SOFTWARE'], 'nginx') === 0) {
+		    $phpVm->header('X-Accel-Redirect: ' . $data['derivativePath']);
+		} else {
+		    $phpVm->header('X-Sendfile: ' . $data['derivativePath']);
+		}
+	        return null;
+	    }
+
 	    /*
 	     * Don't use readfile() because it buffers the entire file in memory.  Profiling shows
 	     * that this approach is as efficient as fpassthru() but we get to call

--- a/modules/core/classes/Gallery.class
+++ b/modules/core/classes/Gallery.class
@@ -867,7 +867,23 @@ class Gallery {
 
 	$base = $this->getConfig('data.gallery.base');
 	$path = $base . $relativePath;
-	if (file_exists($path) && $fd = fopen($path, 'rb')) {
+
+	if ($this->getConfig('useSendFile') && file_exists($path)) {
+		header('Content-Disposition: inline; filename="' . $filename . '"');
+		if (strpos($_SERVER['SERVER_SOFTWARE'], 'lighttpd') === 0) {
+			header('X-Sendfile: ' . $path);
+			header('Last-Modified: ' . $lastModified);
+		} else if (strpos($_SERVER['SERVER_SOFTWARE'], 'nginx') === 0) {
+			header('X-Accel-Redirect: ' . $path);
+			/* NGINX adds a Last-Modified header itself */
+		} else {
+			header('X-Sendfile: ' . $path);
+			/* Apache adds a Last-Modified header itself */
+		}
+		header('Content-type: ' . $mimeType);
+		/* Content-Length is added by Apache, lighttpd and nginx itself */
+		return true;
+	} elseif (file_exists($path) && $fd = fopen($path, 'rb')) {
 	    header('Content-Disposition: inline; filename="' . $filename . '"');
 	    header('Last-Modified: ' . $lastModified);
 	    header('Content-type: ' . $mimeType);


### PR DESCRIPTION
This patch adds the possibility to send image files directly through the
web server, bypassing PHP. This results in increased performance and
less load on the web server.

The ngnix part is from Mike Miller's patch posted at http://gallery.menalto.com/node/83110.
